### PR TITLE
Proxy support

### DIFF
--- a/lib/selenium/client/protocol.rb
+++ b/lib/selenium/client/protocol.rb
@@ -83,7 +83,19 @@ module Selenium
       def http_post(data)
         start = Time.now
         called_from = caller.detect{|line| line !~ /(selenium-client|vendor|usr\/lib\/ruby|\(eval\))/i}
-        http = Net::HTTP.new(@host, @port)
+        
+        env_proxy = ENV['http_proxy'] || ENV['HTTP_PROXY']
+        if env_proxy
+          uri = URI.parse(env_proxy)
+          proxy_host = uri.host
+          proxy_port = uri.port
+          proxy_user, proxy_pass = uri.userinfo.split(/:/) if uri.userinfo
+          http = Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_pass).new(@host, @port)
+        else
+          http = Net::HTTP.new(@host, @port)
+        end
+        
+        
         http.open_timeout = default_timeout_in_seconds
         http.read_timeout = default_timeout_in_seconds
         response = http.post('/selenium-server/driver/', data, HTTP_HEADERS)


### PR DESCRIPTION
Hi there,

I've added support for the http_proxy / HTTP_PROXY environment variable.  Currently only tested on my mac.

I think that ideally using the environment variable or not should be an option to the constructor.  Maybe something like:

```
@browser = Selenium::Client::Driver.new( :http_proxy => true ) # use environment variable
@browser = Selenium::Client::Driver.new( :http_proxy => 'http://user:pass@proxy:port' ) # use this proxy
@browser = Selenium::Client::Driver.new( :http_proxy => false ) # no proxy (the default)
```
