### PR TITLE
Thoughts about adding this method?

### DIFF
--- a/lib/selenium/client/legacy_driver.rb
+++ b/lib/selenium/client/legacy_driver.rb
@@ -144,6 +144,15 @@ module Selenium
         def click(locator)
             remote_control_command("click", [locator,])
         end
+        
+        # Clicks on a link, button, checkbox or radio button and waits for the new 
+        # page to load.  The default timeout is 5000 milliseconds
+        #
+        # 'locator' is an element locator
+        def clickAndWaitForPageToLoad(locator, timeout=5000)
+            remote_control_command("click", [locator,])
+            waitForPageToLoad(timeout)
+        end
 
 
         # Double clicks on a link, button, checkbox or radio button. If the double click action


### PR DESCRIPTION
Added a clickAndWaitForPageToLoad method.  This is something we implemented on our end for our C# tests and has worked quite nicely.  It eliminates the need to call the click and waitForPageToLoad method seperately, in certain situations.
